### PR TITLE
Slight wording change on help

### DIFF
--- a/davtest.pl
+++ b/davtest.pl
@@ -591,7 +591,7 @@ sub usage {
     print "			auto - for any succeeded test\n";
     print "			ext - extension matching file name(s) in backdoors/ dir\n";
     print " -uploadfile+	upload this file (requires -uploadloc)\n";
-    print " -uploadloc+	upload file to this location/name (requires -uploadfile)\n";
+    print " -uploadloc+	upload file to this relative location/name (requires -uploadfile)\n";
     print " -url+		url of DAV location\n";
     print "\n";
     print "Example: $0 -url http://localhost/davdir\n";


### PR DESCRIPTION
I know it seems silly, but when this failed with a full url and the tool just said:

```
********************************************************
 Testing DAV connection
OPEN            SUCCEED:                http://***/webdav
********************************************************
 unless  Uploading file
Upload failed: put shell.php failed
```

I ended up switching to cadaver. Only realised after I'd finished the CTF that the path is supposed to be relative to the webdav root.